### PR TITLE
msm8996: gralloc1: Allow sign conversion errors for kernel headers

### DIFF
--- a/msm8996/libgralloc1/Android.mk
+++ b/msm8996/libgralloc1/Android.mk
@@ -21,6 +21,9 @@ LOCAL_HEADER_LIBRARIES        := libhardware_headers
 LOCAL_EXPORT_HEADER_LIBRARY_HEADERS := libhardware_headers liblog_headers
 LOCAL_SHARED_LIBRARIES        := $(common_libs) libqdMetaData libsync
 LOCAL_CFLAGS                  := $(common_flags) -DLOG_TAG=\"qdgralloc\" -fPIC -Wall -std=c++11 -Werror
+ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
+LOCAL_CFLAGS                  += -Wno-sign-conversion
+endif
 LOCAL_CLANG                   := true
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps) $(kernel_deps)
 LOCAL_SRC_FILES               := gr_utils.cpp \


### PR DESCRIPTION
* The msm_media_info.h header contains many instances of signed/unsigned
  mismatches, so allow sign conversion errors when compiling against the
  actual kernel headers.

Change-Id: I9dcba81b5ec8a793c7eb8e6c446038ef60f8790e